### PR TITLE
Update README: Require NVM

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Drupal 8 profile to create a drupal installation that consume NPM components and
 # Getting started
 To get started you will need:
 * NPM (>= 4)
+* NVM (Node Version Manager): https://github.com/creationix/nvm . To be installed as per the NVM README and not via NPM.
 * Sample components can be found [here](https://www.npmjs.com/~eurostar-npm)
 
 ## Installation


### PR DESCRIPTION
Hi Vijay,

_build.sh_ requires NVM to be installed.

I tried installing NVM via NPM (`npm install nvm`) and via Homebrew (`brew install nvm`) but it seems these installation methods are deprecated. When running NVM installed via these methods, I get an error:
> This is not the package you are looking for: please go to http://nvm.sh

So I installed NVM as per the instructions on https://github.com/creationix/nvm/blob/master/README.markdown and it works. When running _build.sh_ , the `nvm` commands finally worked.

This pull request updates the _README.md_ file to reflect this.

Thanks,
Eugene
